### PR TITLE
adds `<<removeaudiogroup>>` to the Table of Contents

### DIFF
--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -94,6 +94,7 @@
 	* [`<<createplaylist>>`](#macros-macro-createplaylist)
 	* [`<<playlist>>`](#macros-macro-playlist)
 	* [`<<masteraudio>>`](#macros-macro-masteraudio)
+	* [`<<removeaudiogroup>>`](#macros-macro-removeaudiogroup)
 	* [`<<removeplaylist>>`](#macros-macro-removeplaylist)
 	* [`<<waitforaudio>>`](#macros-macro-waitforaudio)
 * [Miscellaneous Macros](#macros-miscellaneous)


### PR DESCRIPTION
There was no link to [`<<removeaudiogroup>>`](https://www.motoslave.net/sugarcube/2/docs/#macros-macro-removeaudiogroup) in the Table of Contents. PR to add that line.