### PR TITLE
Changed README.md word: build.js outputs to `build` dir, not `dist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You should now have SugarCube and all dependencies downloaded, so you may build 
 node build.js
 ```
 
-Assuming that completed with no errors, the story format, in Twine 1 and Twine 2 flavors, should be output to the `dist` directory.  Congratulations!
+Assuming that completed with no errors, the story format, in Twine 1 and Twine 2 flavors, should be output to the `build` directory.  Congratulations!
 
 **NOTE:** SugarCube's development dependencies are occasionally updated.  If you receive errors when attempting to build, then you probably need to update your cached dependencies.  You may do this via the `npm update` command or, in extreme cases, by running `npm uninstall` and `npm install` in order.
 


### PR DESCRIPTION
I'm proposing this change based off of my experience of following these steps.

```bash
$ node build.js 
Starting builds...

Building Twine 1.x version:
 -> assembling libraries...
 -> compiling JavaScript...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
 -> compiling CSS...
 -> building: "build\twine1\sugarcube-2\header.html"
 -> copying : "build\twine1\sugarcube-2\sugarcube-2.py"
 -> copying : "build\twine1\sugarcube-2\LICENSE"

Building Twine 2.x version:
 -> assembling libraries...
 -> compiling JavaScript...
 -> compiling CSS...
 -> building: "build\twine2\sugarcube-2\format.js"
 -> copying : "build\twine2\sugarcube-2\icon.svg"
 -> copying : "build\twine2\sugarcube-2\LICENSE"

Builds complete!  (check the "build" directory)
```

Running the script ends with this output:

> (check the "build" directory)

I feel like there might be a step to output into the `dist` dir, but it's not `node build.js`.