### PR TITLE
FIX, UPDATE, DOC: General debugging improvements; resolves #47

### DIFF
--- a/docs/api/api-config.md
+++ b/docs/api/api-config.md
@@ -11,6 +11,134 @@ The `Config` object controls various aspects of SugarCube's behavior.
 
 
 <!-- ***************************************************************************
+	General
+**************************************************************************** -->
+## General Settings<!-- legacy --><span id="config-api-miscellaneous"></span><!-- /legacy --> {#config-api-general}
+
+<!-- *********************************************************************** -->
+
+### `Config.addVisitedLinkClass` ↔ *boolean* (default: `false`) {#config-api-property-addvisitedlinkclass}
+
+Determines whether the `link-visited` class is added to internal passage links that go to previously visited passages—i.e., the passage already exists within the story history.
+
+<p role="note"><b>Note:</b>
+You <em>must</em> provide your own styling for the <code>link-visited</code> class as none is provided by default.
+</p>
+
+#### History:
+
+* `v2.0.0`: Introduced.
+
+#### Examples:
+
+```js
+Config.addVisitedLinkClass = true;
+```
+
+#### CSS styles:
+
+You will also need to specify a `.link-visited` style that defines the properties visited links should have. For example:
+
+```css
+.link-visited {
+	color: purple;
+}
+```
+
+<!-- *********************************************************************** -->
+
+### `Config.cleanupWikifierOutput` ↔ *boolean* (default: `false`) {#config-api-property-cleanupwikifieroutput}
+
+Determines whether the output of the Wikifier is post-processed into more sane markup—i.e., where appropriate, it tries to transition the plethora of `<br>` elements into `<p>` elements.
+
+#### History:
+
+* `v2.0.0`: Introduced.
+
+#### Examples:
+
+```js
+Config.cleanupWikifierOutput = true;
+```
+
+<!-- *********************************************************************** -->
+
+### `Config.debug` ↔ *boolean* (default: `false`) {#config-api-property-debug}
+
+Indicates whether SugarCube is running in test mode, which enables debug views.  See the [*Test Mode* guide](#guide-test-mode) for more information.
+
+<p role="note"><b>Note:</b>
+This property is automatically set based on whether you're using a testing mode in a Twine compiler—i.e., <em>Test</em> mode in Twine&nbsp;2, <em>Test Play From Here</em> in Twine&nbsp;1, or the test mode option (<code>-t</code>, <code>--test</code>) in Tweego.  You may, however, forcibly enable it if you need to for some reason—e.g., if you're using another compiler, which doesn't offer a way to enable test mode.
+</p>
+
+#### History:
+
+* `v2.2.0`: Introduced.
+
+#### Examples:
+
+##### Forcibly enabling test mode
+
+```js
+// Forcibly enable test mode
+Config.debug = true;
+```
+
+##### Check if test mode is enabled via JavaScript
+
+```js
+if (Config.debug) {
+	/* do something debug related */
+}
+```
+
+##### Check if test mode is enabled via macros
+
+```
+<<if Config.debug>>
+	/* do something debug related */
+<</if>>
+```
+
+<!-- *********************************************************************** -->
+
+### `Config.enableOptionalDebugging` ↔ *boolean* (default: `false`) {#config-api-property-enableoptionaldebugging}
+
+Determines whether various optional debugging errors and warnings are enabled.
+
+List of errors and warnings: *(not exhaustive)*
+
+* [`<<if>>` macro](#macros-macro-if) assignment error.  If enabled, returns an error when the `=` assignment operator is used within its conditional—e.g., `<<if $suspect = "Bob">>`.  Does not flag other assignment operators.
+
+#### History:
+
+* `v2.37.0`: Introduced.
+
+#### Examples:
+
+```js
+Config.enableOptionalDebugging = true;
+```
+
+<!-- *********************************************************************** -->
+
+### `Config.loadDelay` ↔ *integer* (default: `0`) {#config-api-property-loaddelay}
+
+Sets the integer delay (in milliseconds) before the loading screen is dismissed, once the document has signaled its readiness.  Not generally necessary, however, some browsers render slower than others and may need a little extra time to get a media-heavy page done.  This allows you to fine tune for those cases.
+
+#### History:
+
+* `v2.0.0`: Introduced.
+
+#### Examples:
+
+```js
+// Delay the dismissal of the loading screen by 2000ms (2s)
+Config.loadDelay = 2000;
+```
+
+
+<!-- ***************************************************************************
 	Audio
 **************************************************************************** -->
 ## Audio Settings {#config-api-audio}
@@ -106,27 +234,6 @@ Config.history.maxStates = 25;
 
 <!-- *********************************************************************** -->
 
-### `Config.macros.ifAssignmentError` ↔ *boolean* (default: `true`) {#config-api-property-macros-ifassignmenterror}
-
-Determines whether the [`<<if>>` macro](#macros-macro-if) returns an error when the `=` assignment operator is used within its conditional—e.g., `<<if $suspect = "Bob">>`.  Does not flag other assignment operators.
-
-<p role="note"><b>Note:</b>
-This setting exists because it's unlikely that you'll ever want to actually perform an assignment within a conditional expression and typing <code>=</code> when you meant <code>===</code> (or <code>==</code>) is a fairly easy mistake to make—either from a finger slip or because you just don't know the difference between the operators.
-</p>
-
-#### History:
-
-* `v2.0.0`: Introduced.
-
-#### Examples:
-
-```js
-// No error is returned when = is used within an <<if>> or <<elseif>> conditional
-Config.macros.ifAssignmentError = false;
-```
-
-<!-- *********************************************************************** -->
-
 ### `Config.macros.maxLoopIterations` ↔ *integer* (default: `1000`) {#config-api-property-macros-maxloopiterations}
 
 Sets the maximum number of iterations allowed before the [`<<for>>` macro](#macros-macro-for) conditional forms are terminated with an error.
@@ -179,6 +286,19 @@ Determines whether the [`<<type>>` macro](#macros-macro-type) types out content 
 // Do not type on previously visited passages
 Config.macros.typeVisitedPassages = false;
 ```
+
+<!-- *********************************************************************** -->
+
+### <span class="deprecated">`Config.macros.ifAssignmentError` ↔ *boolean* (default: `true`)</span> {#config-api-property-macros-ifassignmenterror}
+
+<p role="note" class="warning"><b>Deprecated:</b>
+This setting has been deprecated and should no longer be used.  See the <a href="#config-api-property-enableoptionaldebugging"><code>Config.enableOptionalDebugging</code></a> setting for its replacement.
+</p>
+
+#### History:
+
+* `v2.0.0`: Introduced.
+* `v2.37.0`: Deprecated in favor of the `Config.enableOptionalDebugging` setting.
 
 
 <!-- ***************************************************************************
@@ -723,112 +843,4 @@ The story title is not included in updates because SugarCube uses it as the basi
 ```js
 // If you don't need those elements to update
 Config.ui.updateStoryElements = false;
-```
-
-
-<!-- ***************************************************************************
-	Miscellaneous
-**************************************************************************** -->
-## Miscellaneous Settings {#config-api-miscellaneous}
-
-<!-- *********************************************************************** -->
-
-### `Config.addVisitedLinkClass` ↔ *boolean* (default: `false`) {#config-api-property-addvisitedlinkclass}
-
-Determines whether the `link-visited` class is added to internal passage links that go to previously visited passages—i.e., the passage already exists within the story history.
-
-<p role="note"><b>Note:</b>
-You <em>must</em> provide your own styling for the <code>link-visited</code> class as none is provided by default.
-</p>
-
-#### History:
-
-* `v2.0.0`: Introduced.
-
-#### Examples:
-
-```js
-Config.addVisitedLinkClass = true;
-```
-
-#### CSS styles:
-
-You will also need to specify a `.link-visited` style that defines the properties visited links should have. For example:
-
-```css
-.link-visited {
-	color: purple;
-}
-```
-
-<!-- *********************************************************************** -->
-
-### `Config.cleanupWikifierOutput` ↔ *boolean* (default: `false`) {#config-api-property-cleanupwikifieroutput}
-
-Determines whether the output of the Wikifier is post-processed into more sane markup—i.e., where appropriate, it tries to transition the plethora of `<br>` elements into `<p>` elements.
-
-#### History:
-
-* `v2.0.0`: Introduced.
-
-#### Examples:
-
-```js
-Config.cleanupWikifierOutput = true;
-```
-
-<!-- *********************************************************************** -->
-
-### `Config.debug` ↔ *boolean* (default: `false`) {#config-api-property-debug}
-
-Indicates whether SugarCube is running in test mode, which enables debug views.  See the [*Test Mode* guide](#guide-test-mode) for more information.
-
-<p role="note"><b>Note:</b>
-This property is automatically set based on whether you're using a testing mode in a Twine compiler—i.e., <em>Test</em> mode in Twine&nbsp;2, <em>Test Play From Here</em> in Twine&nbsp;1, or the test mode option (<code>-t</code>, <code>--test</code>) in Tweego.  You may, however, forcibly enable it if you need to for some reason—e.g., if you're using another compiler, which doesn't offer a way to enable test mode.
-</p>
-
-#### History:
-
-* `v2.2.0`: Introduced.
-
-#### Examples:
-
-##### Forcibly enabling test mode
-
-```js
-// Forcibly enable test mode
-Config.debug = true;
-```
-
-##### Check if test mode is enabled via JavaScript
-
-```js
-if (Config.debug) {
-	/* do something debug related */
-}
-```
-
-##### Check if test mode is enabled via macros
-
-```
-<<if Config.debug>>
-	/* do something debug related */
-<</if>>
-```
-
-<!-- *********************************************************************** -->
-
-### `Config.loadDelay` ↔ *integer* (default: `0`) {#config-api-property-loaddelay}
-
-Sets the integer delay (in milliseconds) before the loading screen is dismissed, once the document has signaled its readiness.  Not generally necessary, however, some browsers render slower than others and may need a little extra time to get a media-heavy page done.  This allows you to fine tune for those cases.
-
-#### History:
-
-* `v2.0.0`: Introduced.
-
-#### Examples:
-
-```js
-// Delay the dismissal of the loading screen by 2000ms (2s)
-Config.loadDelay = 2000;
 ```

--- a/docs/api/api-config.md
+++ b/docs/api/api-config.md
@@ -65,10 +65,14 @@ Config.cleanupWikifierOutput = true;
 
 ### `Config.debug` ↔ *boolean* (default: `false`) {#config-api-property-debug}
 
-Indicates whether SugarCube is running in test mode, which enables debug views.  See the [*Test Mode* guide](#guide-test-mode) for more information.
+Indicates whether SugarCube is running in test mode, which enables debug views and various optional debugging errors and warnings.  See the [*Test Mode* guide](#guide-test-mode) for more information.
 
 <p role="note"><b>Note:</b>
-This property is automatically set based on whether you're using a testing mode in a Twine compiler—i.e., <em>Test</em> mode in Twine&nbsp;2, <em>Test Play From Here</em> in Twine&nbsp;1, or the test mode option (<code>-t</code>, <code>--test</code>) in Tweego.  You may, however, forcibly enable it if you need to for some reason—e.g., if you're using another compiler, which doesn't offer a way to enable test mode.
+This setting is automatically set based on whether you're using a testing mode in a Twine compiler—i.e., <em>Test</em> mode in Twine&nbsp;2, <em>Test Play From Here</em> in Twine&nbsp;1, or the test mode option (<code>-t</code>, <code>--test</code>) in Tweego.  You may, however, forcibly enable it if you need to for some reason—e.g., if you're using another compiler, which doesn't offer a way to enable test mode.
+</p>
+
+<p role="note" class="see"><b>See Also:</b>
+<a href="#config-api-property-enableoptionaldebugging"><code>Config.enableOptionalDebugging</code> setting</a>.
 </p>
 
 #### History:
@@ -104,9 +108,13 @@ if (Config.debug) {
 
 ### `Config.enableOptionalDebugging` ↔ *boolean* (default: `false`) {#config-api-property-enableoptionaldebugging}
 
-Determines whether various optional debugging errors and warnings are enabled.
+Determines whether various optional debugging errors and warnings are enabled outside of test mode.
 
-List of errors and warnings: *(not exhaustive)*
+<p role="note" class="see"><b>See Also:</b>
+<a href="#config-api-property-debug"><code>Config.debug</code> setting</a>.
+</p>
+
+List of optional errors and warnings: *(not exhaustive)*
 
 * [`<<if>>` macro](#macros-macro-if) assignment error.  If enabled, returns an error when the `=` assignment operator is used within its conditional—e.g., `<<if $suspect = "Bob">>`.  Does not flag other assignment operators.
 

--- a/docs/guides/guide-code-updates.md
+++ b/docs/guides/guide-code-updates.md
@@ -104,6 +104,10 @@ Some changes within this version are <strong>breaking changes</strong> that you 
 	</thead>
 	<tbody>
 		<tr>
+			<td><code>Config.macros.ifAssignError</code></td>
+			<td>This setting has been deprecated and should no longer be used.  See the <a href="#config-api-property-enableoptionaldebugging"><code>Config.enableOptionalDebugging</code></a> setting for its replacement.</td>
+		</tr>
+		<tr>
 			<td><code>Config.passages.descriptions</code></td>
 			<td>This setting has been deprecated and should no longer be used.  See the <a href="#config-api-property-saves-descriptions"><code>Config.saves.descriptions</code></a> setting for its replacement.</td>
 		</tr>

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -277,6 +277,12 @@
 
 ## [`Config` API](#config-api)
 
+* [General Settings](#config-api-general)
+	* [`Config.addVisitedLinkClass`](#config-api-property-addvisitedlinkclass)
+	* [`Config.cleanupWikifierOutput`](#config-api-property-cleanupwikifieroutput)
+	* [`Config.debug`](#config-api-property-debug)
+ * [`Config.enableOptionalDebugging`](#config-api-property-enableoptionaldebugging)
+	* [`Config.loadDelay`](#config-api-property-loaddelay)
 * [Audio Settings](#config-api-audio)
 	* [`Config.audio.pauseOnFadeToZero`](#config-api-property-audio-pauseonfadetozero)
 	* [`Config.audio.preloadMetadata`](#config-api-property-audio-preloadmetadata)
@@ -284,7 +290,6 @@
 	* [`Config.history.controls`](#config-api-property-history-controls)
 	* [`Config.history.maxStates`](#config-api-property-history-maxstates)
 * [Macros Settings](#config-api-macros)
-	* [`Config.macros.ifAssignmentError`](#config-api-property-macros-ifassignmenterror)
 	* [`Config.macros.maxLoopIterations`](#config-api-property-macros-maxloopiterations)
 	* [`Config.macros.typeSkipKey`](#config-api-property-macros-typeskipkey)
 	* [`Config.macros.typeVisitedPassages`](#config-api-property-macros-typevisitedpassages)
@@ -306,11 +311,6 @@
 * [UI Settings](#config-api-ui)
 	* [`Config.ui.stowBarInitially`](#config-api-property-ui-stowbarinitially)
 	* [`Config.ui.updateStoryElements`](#config-api-property-ui-updatestoryelements)
-* [Miscellaneous Settings](#config-api-miscellaneous)
-	* [`Config.addVisitedLinkClass`](#config-api-property-addvisitedlinkclass)
-	* [`Config.cleanupWikifierOutput`](#config-api-property-cleanupwikifieroutput)
-	* [`Config.debug`](#config-api-property-debug)
-	* [`Config.loadDelay`](#config-api-property-loaddelay)
 
 ## [`Dialog` API](#dialog-api)
 

--- a/src/config.js
+++ b/src/config.js
@@ -10,10 +10,11 @@
 
 var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 	// General settings.
-	let _debug                 = false;
-	let _addVisitedLinkClass   = false;
-	let _cleanupWikifierOutput = false;
-	let _loadDelay             = 0;
+	let _debug                   = false;
+	let _addVisitedLinkClass     = false;
+	let _cleanupWikifierOutput   = false;
+	let _enableOptionalDebugging = false;
+	let _loadDelay               = 0;
 
 	// Audio settings.
 	let _audioPauseOnFadeToZero = true;
@@ -24,7 +25,6 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 	let _historyMaxStates = 40;
 
 	// Macros settings.
-	let _macrosIfAssignmentError   = true;
 	let _macrosMaxLoopIterations   = 1000;
 	let _macrosTypeSkipKey         = '\x20'; // Space
 	let _macrosTypeVisitedPassages = true;
@@ -58,13 +58,14 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 		Error Constants.
 	*******************************************************************************/
 
-	const errPassagesDescriptionsDeprecated = '[DEPRECATED] Config.passages.descriptions has been deprecated, see Config.saves.descriptions instead';
-	const errSavesAutoloadDeprecated        = '[DEPRECATED] Config.saves.autoload has been deprecated, see the Save.browser.continue API instead';
-	const _baseSavesAutosaveDeprecated      = '[DEPRECATED] Config.saves.autosave has been deprecated';
-	const errSavesOnLoadDeprecated          = '[DEPRECATED] Config.saves.onLoad has been deprecated, see the Save.onLoad API instead';
-	const errSavesOnSaveDeprecated          = '[DEPRECATED] Config.saves.onSave has been deprecated, see the Save.onSave API instead';
-	const errSavesSlotsDeprecated           = '[DEPRECATED] Config.saves.slots has been deprecated, see Config.saves.maxSlotSaves instead';
-	const errSavesTryDiskOnMobileDeprecated = '[DEPRECATED] Config.saves.tryDiskOnMobile has been deprecated';
+	const errMacrosIfAssignmentErrorDeprecated = '[DEPRECATED] Config.macros.ifAssignmentError has been deprecated, see Config.enableOptionalDebugging instead';
+	const errPassagesDescriptionsDeprecated    = '[DEPRECATED] Config.passages.descriptions has been deprecated, see Config.saves.descriptions instead';
+	const errSavesAutoloadDeprecated           = '[DEPRECATED] Config.saves.autoload has been deprecated, see the Save.browser.continue API instead';
+	const _baseSavesAutosaveDeprecated         = '[DEPRECATED] Config.saves.autosave has been deprecated';
+	const errSavesOnLoadDeprecated             = '[DEPRECATED] Config.saves.onLoad has been deprecated, see the Save.onLoad API instead';
+	const errSavesOnSaveDeprecated             = '[DEPRECATED] Config.saves.onSave has been deprecated, see the Save.onSave API instead';
+	const errSavesSlotsDeprecated              = '[DEPRECATED] Config.saves.slots has been deprecated, see Config.saves.maxSlotSaves instead';
+	const errSavesTryDiskOnMobileDeprecated    = '[DEPRECATED] Config.saves.tryDiskOnMobile has been deprecated';
 
 
 	/*******************************************************************************
@@ -84,6 +85,8 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 		get cleanupWikifierOutput() { return _cleanupWikifierOutput; },
 		set cleanupWikifierOutput(value) { _cleanupWikifierOutput = Boolean(value); },
 
+		get enableOptionalDebugging() { return _enableOptionalDebugging; },
+		set enableOptionalDebugging(value) { _enableOptionalDebugging = Boolean(value); },
 		get loadDelay() { return _loadDelay; },
 		set loadDelay(value) {
 			if (!Number.isSafeInteger(value) || value < 0) {
@@ -139,9 +142,6 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 			Macros settings.
 		*/
 		macros : Object.freeze({
-			get ifAssignmentError() { return _macrosIfAssignmentError; },
-			set ifAssignmentError(value) { _macrosIfAssignmentError = Boolean(value); },
-
 			get maxLoopIterations() { return _macrosMaxLoopIterations; },
 			set maxLoopIterations(value) {
 				if (!Number.isSafeInteger(value) || value < 1) {
@@ -156,6 +156,17 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 
 			get typeVisitedPassages() { return _macrosTypeVisitedPassages; },
 			set typeVisitedPassages(value) { _macrosTypeVisitedPassages = Boolean(value); }
+
+			/* legacy */
+			// Die if the deprecated macros if assignment error getter is accessed.
+			get ifAssignmentError() { throw new Error(errMacrosIfAssignmentErrorDeprecated); },
+			// Warn if the deprecated macros if assignment error setter is assigned to,
+			// while also setting `Config.enableOptionalDebugging` for compatibilities sake.
+			set ifAssignmentError(value) {
+				console.warn(errMacrosIfAssignmentErrorDeprecated);
+				Config.enableOptionalDebugging = value;
+			}
+			/* /legacy */
 		}),
 
 		/*
@@ -228,7 +239,7 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 			},
 
 			/* legacy */
-			// Die if deprecated passages descriptions getter is accessed.
+			// Die if the deprecated passages descriptions getter is accessed.
 			get descriptions() { throw new Error(errPassagesDescriptionsDeprecated); },
 			// Warn if deprecated passages descriptions setter is assigned to,
 			// then pass the value to the `Config.saves.descriptions` for
@@ -342,12 +353,12 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 			set version(value) { _savesVersion = value; },
 
 			/* legacy */
-			// Warn if deprecated autoload getter is accessed.
+			// Warn if the deprecated autoload getter is accessed.
 			get autoload() {
 				console.warn(errSavesAutoloadDeprecated);
 				return _savesAutoload;
 			},
-			// Warn if deprecated autoload setter is assigned to.
+			// Warn if the deprecated autoload setter is assigned to.
 			set autoload(value) {
 				console.warn(errSavesAutoloadDeprecated);
 
@@ -366,7 +377,7 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 				_savesAutoload = value;
 			},
 
-			// Die if deprecated saves autosave getter is accessed.
+			// Die if the deprecated saves autosave getter is accessed.
 			get autosave() {
 				throw new Error(`${_baseSavesAutosaveDeprecated}, see Config.saves.maxAutoSaves and Config.saves.isAllowed instead`);
 			},
@@ -422,27 +433,27 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 				}
 			},
 
-			// Die if deprecated saves onLoad handler getter is accessed.
+			// Die if the deprecated saves onLoad handler getter is accessed.
 			get onLoad() { throw new Error(errSavesOnLoadDeprecated); },
-			// Warn if deprecated saves onLoad handler setter is assigned to, then
+			// Warn if the deprecated saves onLoad handler setter is assigned to, then
 			// pass the handler to the `Save.onLoad` API for compatibilities sake.
 			set onLoad(value) {
 				console.warn(errSavesOnLoadDeprecated);
 				Save.onLoad.add(value);
 			},
 
-			// Die if deprecated saves onSave handler getter is accessed.
+			// Die if the deprecated saves onSave handler getter is accessed.
 			get onSave() { throw new Error(errSavesOnSaveDeprecated); },
-			// Warn if deprecated saves onSave handler setter is assigned to, then
+			// Warn if the deprecated saves onSave handler setter is assigned to, then
 			// pass the handler to the `Save.onSave` API for compatibilities sake.
 			set onSave(value) {
 				console.warn(errSavesOnSaveDeprecated);
 				Save.onSave.add(value);
 			},
 
-			// Die if deprecated saves slots getter is accessed.
+			// Die if the deprecated saves slots getter is accessed.
 			get slots() { throw new Error(errSavesSlotsDeprecated); },
-			// Warn if deprecated saves slots setter is assigned to, then pass
+			// Warn if the deprecated saves slots setter is assigned to, then pass
 			// the value to the `Config.saves.maxSlotSaves` for compatibilities
 			// sake.
 			set slots(value) {
@@ -450,13 +461,13 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 				Config.saves.maxSlotSaves = value;
 			},
 
-			// Warn if deprecated saves tryDiskOnMobile getter is accessed, then
+			// Warn if the deprecated saves tryDiskOnMobile getter is accessed, then
 			// return `true`.
 			get tryDiskOnMobile() {
 				console.warn(errSavesTryDiskOnMobileDeprecated);
 				return true;
 			},
-			// Warn if deprecated saves tryDiskOnMobile setter is assigned to.
+			// Warn if the deprecated saves tryDiskOnMobile setter is assigned to.
 			set tryDiskOnMobile(value) { console.warn(errSavesTryDiskOnMobileDeprecated); }
 			/* /legacy */
 		}),

--- a/src/config.js
+++ b/src/config.js
@@ -87,6 +87,7 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 
 		get enableOptionalDebugging() { return _enableOptionalDebugging; },
 		set enableOptionalDebugging(value) { _enableOptionalDebugging = Boolean(value); },
+
 		get loadDelay() { return _loadDelay; },
 		set loadDelay(value) {
 			if (!Number.isSafeInteger(value) || value < 0) {

--- a/src/config.js
+++ b/src/config.js
@@ -10,9 +10,9 @@
 
 var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 	// General settings.
-	let _debug                   = false;
 	let _addVisitedLinkClass     = false;
 	let _cleanupWikifierOutput   = false;
+	let _debug                   = false;
 	let _enableOptionalDebugging = false;
 	let _loadDelay               = 0;
 
@@ -76,14 +76,14 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 		/*
 			General settings.
 		*/
-		get debug() { return _debug; },
-		set debug(value) { _debug = Boolean(value); },
-
 		get addVisitedLinkClass() { return _addVisitedLinkClass; },
 		set addVisitedLinkClass(value) { _addVisitedLinkClass = Boolean(value); },
 
 		get cleanupWikifierOutput() { return _cleanupWikifierOutput; },
 		set cleanupWikifierOutput(value) { _cleanupWikifierOutput = Boolean(value); },
+
+		get debug() { return _debug; },
+		set debug(value) { _debug = Boolean(value); },
 
 		get enableOptionalDebugging() { return _enableOptionalDebugging; },
 		set enableOptionalDebugging(value) { _enableOptionalDebugging = Boolean(value); },

--- a/src/macro/macros/if.js
+++ b/src/macro/macros/if.js
@@ -63,7 +63,7 @@ Macro.add('if', {
 							return this.error(`no conditional expression specified for <<${this.payload[i].name}>> clause${i > 0 ? ` (#${i})` : ''}`);
 						}
 						else if (
-							(Config.debug || Config.macros.ifAssignmentError)
+							(Config.debug || Config.enableOptionalDebugging)
 							&& isAssignRE.test(this.payload[i].args.full.replace(isLiteralRE, ''))
 						) {
 							return this.error(`assignment operator found within <<${this.payload[i].name}>> clause${i > 0 ? ` (#${i})` : ''} (perhaps you meant to use an equality operator: ==, ===, eq, is), invalid: ${this.payload[i].args.raw}`);


### PR DESCRIPTION
* Fix `<<if>>` macro assignment error to ignore string internals during its checks; resolves #47.
* Update `<<if>>` macro assignment error to default to opt-in, rather than opt-out.
* Update test mode to also enable various optional debugging errors and warnings, in addition to debug views and the debug bar.
* Deprecate `Config.ifAssignmentError`, in favor of `Config.enableOptionalDebugging`.
* Add `Config.enableOptionalDebugging`, which enables various optional debugging errors and warnings outside of test mode.