### PR TITLE
fix(scripting): fix passage() return wrong name after using enginePlay with noHistory flag

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -39,6 +39,8 @@ var Engine = (() => { // eslint-disable-line no-unused-vars, no-var
 	// List of objects describing `StoryInterface` elements to update via passages during navigation.
 	let _updating = null;
 
+	// Store current passage title regardless of whether we save it to history
+	let _currentPassageTitle = null;
 
 	/*******************************************************************************************************************
 		Engine Functions.
@@ -457,6 +459,8 @@ var Engine = (() => { // eslint-disable-line no-unused-vars, no-var
 			}
 		});
 
+		_currentPassageTitle = passage.title;
+
 		// Create a new entry in the history.
 		if (!noHistory) {
 			State.create(passage.title);
@@ -794,6 +798,8 @@ var Engine = (() => { // eslint-disable-line no-unused-vars, no-var
 		*/
 		States            : { value : States },
 		minDomActionDelay : { value : minDomActionDelay },
+
+		currentPassageTitle : _currentPassageTitle,
 
 		/*
 			Core Functions.

--- a/src/markup/scripting.js
+++ b/src/markup/scripting.js
@@ -329,7 +329,7 @@ var Scripting = (() => { // eslint-disable-line no-unused-vars, no-var
 		Returns the title of the current passage.
 	*/
 	function passage() {
-		return State.passage;
+		return Engine.currentPassageTitle ?? State.passage;
 	}
 
 	/*


### PR DESCRIPTION
Warn: I'm not sure about that this is the best solution

Steps to reproduce the bug:

- got to some passage (for example `somePassage1`)
- run enginePlay with noHistory=true `enginePlay('somePassage2', true)`
- try to get current passage name using `passage()`

Actual result: I see content from `somePassage2` but `passage()` return `somePassage1`
Expected result: I see content from `somePassage2` and `passage()` return `somePassage2`
