### PR TITLE
Fixes rogue indentation in TOC item

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,7 +17,9 @@
 *.jpg binary
 *.pdf binary
 *.png binary
-*.ttf binary
+*.tif binary
+*.tiff binary
+*.webp binary
 
 # Archives
 *.7z binary

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -284,7 +284,7 @@
 	* [`Config.addVisitedLinkClass`](#config-api-property-addvisitedlinkclass)
 	* [`Config.cleanupWikifierOutput`](#config-api-property-cleanupwikifieroutput)
 	* [`Config.debug`](#config-api-property-debug)
- * [`Config.enableOptionalDebugging`](#config-api-property-enableoptionaldebugging)
+ 	* [`Config.enableOptionalDebugging`](#config-api-property-enableoptionaldebugging)
 	* [`Config.loadDelay`](#config-api-property-loaddelay)
 * [Audio Settings](#config-api-audio)
 	* [`Config.audio.pauseOnFadeToZero`](#config-api-property-audio-pauseonfadetozero)

--- a/src/css/core.css
+++ b/src/css/core.css
@@ -115,6 +115,7 @@ a.link-broken:hover {
 a[disabled],
 span.link-disabled {
 	color: #aaa;
+	cursor: not-allowed !important;
 	/*
 		NOTE: Do not use `pointer-events` here as it disables
 		the display of a cursor in some browsers.


### PR DESCRIPTION
What it says on the tin.

`Config.enableOptionalDebugging`
 had gone a level higher in the list hierarchy.