### PR TITLE
Session compression config option

### DIFF
--- a/docs/api/api-config.md
+++ b/docs/api/api-config.md
@@ -165,6 +165,30 @@ An *integer* `number` value denoting the delay (in milliseconds) before the load
 Config.loadDelay = 2000;
 ```
 
+<!-- *********************************************************************** -->
+
+### `Config.sessionCompression` ↔ * `boolean` (default: `true`) {#config-api-property-sessioncompression}
+
+Determines whether the [Playthrough Session](#guide-state-sessions-and-saving-playthrough-session) data is compressed before being saved to sessionStorage.
+
+<p role="note"><b>Note:</b>
+<code>Config.sessionCompression</code> <em>must be</em> set during story initialization, within either your project's JavaScript section (Twine&nbsp;2: the Story JavaScript; Twine&nbsp;1/Twee: a <code>script</code>-tagged passage) or the <code>StoryInit</code> special passage.  Additionally, it is <strong><em>strongly</em></strong> recommended that you ensure that the size of your Playthrough Session is under 5 MiB at all times.
+</p>
+
+#### History:
+
+* `v2.38.0`: Introduced.
+
+#### Value:
+
+A `boolean` value signifying whether the Playthrough Session data is compressed before being saved to sessionStorage.
+
+#### Examples:
+
+```javascript
+Config.sessionCompression = false;
+```
+
 
 <!-- ***************************************************************************
 	Audio

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -288,6 +288,7 @@
 	* [`Config.debug`](#config-api-property-debug)
  	* [`Config.enableOptionalDebugging`](#config-api-property-enableoptionaldebugging)
 	* [`Config.loadDelay`](#config-api-property-loaddelay)
+	* [`Config.sessionCompression`](#config-api-property-sessioncompression)
 * [Audio Settings](#config-api-audio)
 	* [`Config.audio.pauseOnFadeToZero`](#config-api-property-audio-pauseonfadetozero)
 	* [`Config.audio.preloadMetadata`](#config-api-property-audio-preloadmetadata)

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 	let cfgDebug                   = false;
 	let cfgEnableOptionalDebugging = false;
 	let cfgLoadDelay               = 0;
+	let cfgSessionCompression      = true;
 
 	// Audio settings.
 	let cfgAudioPauseOnFadeToZero = true;
@@ -84,6 +85,9 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 
 			cfgLoadDelay = value;
 		},
+
+		get sessionCompression() { return cfgSessionCompression; },
+		set sessionCompression(value) { cfgSessionCompression = Boolean(value); },
 
 		/*
 			Audio settings.

--- a/src/storage/adapters/webstorage.js
+++ b/src/storage/adapters/webstorage.js
@@ -111,7 +111,7 @@ SimpleStore.adapters.push((() => {
 			// QUESTION: Has `<Storage>.getItem()` ever returned any value other than
 			// `null` for non-existent keys?  I seem to recall a browser bug where
 			// `undefined` was returned, but I can't find any details about it now.
-			if (!Config.sessionCompression && this.#engine === 'sessionStorage') {
+			if (!Config.sessionCompression && this.name === 'sessionStorage') {
 				return value == null ? null : Serial.parse(value); // nullish test
 			}
 			return value == null ? null : WebStorageAdapter.#deserialize(value); // nullish test
@@ -125,7 +125,7 @@ SimpleStore.adapters.push((() => {
 			}
 
 			try {
-				if (!Config.sessionCompression && this.#engine === 'sessionStorage') {
+				if (!Config.sessionCompression && this.name === 'sessionStorage') {
 					this.#engine.setItem(this.#prefix + key, Serial.stringify(value));
 				}
 				else {

--- a/src/storage/adapters/webstorage.js
+++ b/src/storage/adapters/webstorage.js
@@ -6,7 +6,7 @@
 	Use of this source code is governed by a BSD 2-clause "Simplified" License, which may be found in the LICENSE file.
 
 ***********************************************************************************************************************/
-/* global Serial, SimpleStore, exceptionFrom */
+/* global Config, Serial, SimpleStore, exceptionFrom */
 
 SimpleStore.adapters.push((() => {
 	// Adapter readiness state.
@@ -111,6 +111,9 @@ SimpleStore.adapters.push((() => {
 			// QUESTION: Has `<Storage>.getItem()` ever returned any value other than
 			// `null` for non-existent keys?  I seem to recall a browser bug where
 			// `undefined` was returned, but I can't find any details about it now.
+			if (!Config.sessionCompression && this.#engine === 'sessionStorage') {
+				return value == null ? null : Serial.parse(value); // nullish test
+			}
 			return value == null ? null : WebStorageAdapter.#deserialize(value); // nullish test
 		}
 
@@ -122,7 +125,12 @@ SimpleStore.adapters.push((() => {
 			}
 
 			try {
-				this.#engine.setItem(this.#prefix + key, WebStorageAdapter.#serialize(value));
+				if (!Config.sessionCompression && this.#engine === 'sessionStorage') {
+					this.#engine.setItem(this.#prefix + key, Serial.stringify(value));
+				}
+				else {
+					this.#engine.setItem(this.#prefix + key, WebStorageAdapter.#serialize(value));
+				}
 			}
 			catch (ex) {
 				// If the exception is a quota exceeded error, massage it into something


### PR DESCRIPTION
Add a configuration option to disable compression of the `sessionStorage` state value.

This can provide a 3–4× speed improvement when navigating between passages.